### PR TITLE
get rid of the unnecessary warnning

### DIFF
--- a/osfoffline/filesystem_manager/osf_event_handler.py
+++ b/osfoffline/filesystem_manager/osf_event_handler.py
@@ -229,7 +229,6 @@ class OSFEventHandler(FileSystemEventHandler):
     def dispatch(self, event):
         # basically, ignore all events that occur for 'Components' file or folder
         if self._event_is_for_components_file_folder(event):
-            AlertHandler.warn('Cannot have a custom file or folder named Components')
             return
 
         _method_map = {


### PR DESCRIPTION
Purpose
remove the unnecessary warning 

Side Effect
Need to teach user in the training session that don't name any folder components.

[#OSF-5097]