### PR TITLE
[hold][Feature] Errors for illegal characters/Microsoft's reserved words

### DIFF
--- a/osfoffline/polling_osf_manager/polling.py
+++ b/osfoffline/polling_osf_manager/polling.py
@@ -371,25 +371,23 @@ class Poll(object):
         else:
             raise ValueError('in some weird state. figure it out.')
 
-        assert local_file_folder is not None
-        assert remote_file_folder is not None
-
         # recursively handle folder's children
-        if local_file_folder.is_folder:
+        if local_file_folder is not None and remote_file_folder is not None:
+            if local_file_folder.is_folder:
 
-            remote_children = yield from self.osf_query.get_child_files(remote_file_folder)
+                remote_children = yield from self.osf_query.get_child_files(remote_file_folder)
 
-            local_remote_file_folders = self.make_local_remote_tuple_list(local_file_folder.files, remote_children)
+                local_remote_file_folders = self.make_local_remote_tuple_list(local_file_folder.files, remote_children)
 
-            for local, remote in local_remote_file_folders:
-                yield from self._check_file_folder(
-                    local,
-                    remote,
-                    local_parent_file_folder=local_file_folder,
-                    local_node=local_node
-                )
+                for local, remote in local_remote_file_folders:
+                    yield from self._check_file_folder(
+                        local,
+                        remote,
+                        local_parent_file_folder=local_file_folder,
+                        local_node=local_node
+                    )
 
-                    # if we are unable to get children, then we do not try to get and manipulate children
+                        # if we are unable to get children, then we do not try to get and manipulate children
 
     # Create
     @asyncio.coroutine
@@ -429,34 +427,39 @@ class Poll(object):
         # NOTE: develop is not letting me download files. dont know why.
 
         illegal_chars = ['<', '>', ':', '"', '/', '\\', '|', '?', '*']
+        illegal_names = ['con', 'prn', 'aux', 'nul', 'com1', 'com2', 'com3', 'com4', 'com5', 'com6', 'com7', 'com8', 'com9', 'lpt1', 'lpt2', 'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9']
         if not any(x in remote_file_folder.name for x in illegal_chars):
-            # create local file folder in db
-            file_type = File.FILE if isinstance(remote_file_folder, RemoteFile) else File.FOLDER
-            new_file_folder = File(
-                name=remote_file_folder.name,
-                type=file_type,
-                osf_id=remote_file_folder.id,
-                provider=remote_file_folder.provider,
-                osf_path=remote_file_folder.id,
-                user=self.user,
-                parent=local_parent_folder,
-                node=local_node
-            )
-            save(session, new_file_folder)
-
-            if file_type == File.FILE:
-                event = CreateFile(
-                    path=new_file_folder.path,
-                    download_url=remote_file_folder.download_url,
-                    osf_query=self.osf_query
+            if remote_file_folder.name.split('.', 1)[0].lower() not in illegal_names:
+                # create local file folder in db
+                file_type = File.FILE if isinstance(remote_file_folder, RemoteFile) else File.FOLDER
+                new_file_folder = File(
+                    name=remote_file_folder.name,
+                    type=file_type,
+                    osf_id=remote_file_folder.id,
+                    provider=remote_file_folder.provider,
+                    osf_path=remote_file_folder.id,
+                    user=self.user,
+                    parent=local_parent_folder,
+                    node=local_node
                 )
-                yield from self.queue.put(event)
-            elif file_type == File.FOLDER:
-                yield from self.queue.put(CreateFolder(new_file_folder.path))
-            else:
-                raise ValueError('file type is unknown')
+                save(session, new_file_folder)
 
-            return new_file_folder
+                if file_type == File.FILE:
+                    event = CreateFile(
+                        path=new_file_folder.path,
+                        download_url=remote_file_folder.download_url,
+                        osf_query=self.osf_query
+                    )
+                    yield from self.queue.put(event)
+                elif file_type == File.FOLDER:
+                    yield from self.queue.put(CreateFolder(new_file_folder.path))
+                else:
+                    raise ValueError('file type is unknown')
+
+                return new_file_folder
+            else:
+                AlertHandler.warn('{} is a reserved word and therefore cannot be created as named.  Rename this on the OSF to allow for syncing'.format(remote_file_folder.name.split('.', 1)[0]))
+                print('{} is a reserved word and therefore cannot be created as named.  Rename this on the OSF to allow for syncing'.format(remote_file_folder.name.split('.', 1)[0]))
         else:
             AlertHandler.warn('{} contains illegal characters and should be renamed on the OSF to allow for syncing'.format(remote_file_folder.name))
             print('{} contains illegal characters and should be renamed on the OSF to allow for syncing'.format(remote_file_folder.name))

--- a/osfoffline/views/preferences.py
+++ b/osfoffline/views/preferences.py
@@ -185,16 +185,18 @@ class Preferences(QDialog):
             return
 
         for node in nodes:
-            tree_item = QTreeWidgetItem(self.preferences_window.treeWidget)
-            tree_item.setCheckState(self.PROJECT_SYNC_COLUMN, Qt.Unchecked)
-            tree_item.setText(self.PROJECT_NAME_COLUMN, _translate("Preferences", path.make_folder_name(node.name, node_id=node.id)))
+            illegal_chars = ['<', '>', ':', '"', '/', '\\', '|', '?', '*']
+            if not any(x in node.name for x in illegal_chars):
+                tree_item = QTreeWidgetItem(self.preferences_window.treeWidget)
+                tree_item.setCheckState(self.PROJECT_SYNC_COLUMN, Qt.Unchecked)
+                tree_item.setText(self.PROJECT_NAME_COLUMN, _translate("Preferences", path.make_folder_name(node.name, node_id=node.id)))
 
-            if node.id in user.guid_for_top_level_nodes_to_sync:
-                tree_item.setCheckState(self.PROJECT_SYNC_COLUMN, Qt.Checked)
-                if node.id not in self.checked_items:
-                    self.checked_items.append(node.id)
+                if node.id in user.guid_for_top_level_nodes_to_sync:
+                    tree_item.setCheckState(self.PROJECT_SYNC_COLUMN, Qt.Checked)
+                    if node.id not in self.checked_items:
+                        self.checked_items.append(node.id)
 
-            self.tree_items.append((tree_item, node.id))
+                self.tree_items.append((tree_item, node.id))
         self.preferences_window.treeWidget.resizeColumnToContents(self.PROJECT_SYNC_COLUMN)
         self.preferences_window.treeWidget.resizeColumnToContents(self.PROJECT_NAME_COLUMN)
         self.preferences_window.treeWidget.unsetCursor()


### PR DESCRIPTION
Purpose
-
Microsoft has a bunch of rules on file system naming (https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx).  This PR addresses the rules for illegal names and illegal symbols.  

Changes
-
Made it so that the Settings panel won't display a node if the node name contains an illegal symbol (as it wouldn't be able to be created anyways) and then in polling.py created checks before attempting to create the file/folder to see if it's name is valid.  The reason for this is to keep the same namespace available on Windows and Mac/Linux.

Side Effects
-
Currently no check is performed when renaming to see whether the new name is valid or not (not that we can stop this anyways - just provide an error) so if the user names something on Mac with an illegal name or symbol and then someone attempts to sync this file on Windows, it will fail on Windows (but will fail gracefully because of this PR).  Ideally, the user should be prompted that their name change may cause this to occur.  Other than that no potential side effects are known.