### PR TITLE
Fix issue with moving file to a parent folder

### DIFF
--- a/osfoffline/polling_osf_manager/osf_query.py
+++ b/osfoffline/polling_osf_manager/osf_query.py
@@ -197,8 +197,7 @@ class OSFQuery(object):
 
         data = {
             'action': 'move',
-            'path': local_file_folder.parent.osf_path if local_file_folder.parent else '{}:{}'.format(
-                local_file_folder.node_id, local_file_folder.provider),
+            'path': local_file_folder.parent.osf_path if local_file_folder.parent else '/',
             'rename': local_file_folder.name
         }
 


### PR DESCRIPTION
Refs [#OSF-5131]. This PR fixes an error that would be encountered when moving a file from a subfolder to a parent directory.

Forked from #60 per discussion with @himanshuo