### PR TITLE
If server request throws exception,  don't try to download file

### DIFF
--- a/osfoffline/polling_osf_manager/polling_events.py
+++ b/osfoffline/polling_osf_manager/polling_events.py
@@ -200,14 +200,18 @@ def _download_file(path, url, osf_query):
         # FIXME: Consolidate redundant messages
         AlertHandler.warn("Bad Internet Connection")
         logging.warning("Bad Internet Connection")
+        return
     except (aiohttp.errors.HttpMethodNotAllowed, aiohttp.errors.BadHttpMessage):
         AlertHandler.warn("Do not have access to file.")
         logging.warning("Do not have access to file.")
+        return
     except aiohttp.errors.HttpBadRequest:
         AlertHandler.warn("Problem accessing file.")
         logging.exception("Exception caught downloading file.")
+        return
     except Exception:
         logging.exception("Exception caught: problem downloading file.")
+        return
     try:
         with open(path.full_path, 'wb') as fd:
             while True:


### PR DESCRIPTION
Fixes bug reported by Nici: "Local variable 'resp' referenced before assignment" when download operation throws an exception

```
[2015-11-17 06:39:12,646][Thread-10][polling_events.py][WARNING][root]: Bad Internet Connection
[2015-11-17 06:39:12,649][Thread-10][base_events.py][ERROR][asyncio]: Exception in callback Poll.handle_exception(<Task finishe...assignment",)>)
handle: <Handle Poll.handle_exception(<Task finishe...assignment",)>)>
Traceback (most recent call last):
  File "c:\python343\lib\asyncio\events.py", line 120, in _run
  File "C:\Users\IEUser\Documents\GitHub\OSF-Offline\osfoffline\polling_osf_manager\polling.py", line 74, in handle_exception
  File "c:\python343\lib\asyncio\tasks.py", line 238, in _step
  File "C:\Users\IEUser\Documents\GitHub\OSF-Offline\osfoffline\polling_osf_manager\polling.py", line 111, in process_queue
  File "C:\Users\IEUser\Documents\GitHub\OSF-Offline\osfoffline\polling_osf_manager\polling_events.py", line 62, in run
  File "C:\Users\IEUser\Documents\GitHub\OSF-Offline\osfoffline\polling_osf_manager\polling_events.py", line 214, in _download_file
UnboundLocalError: local variable 'resp' referenced before assignment
```