### PR TITLE
[Feature]Redownload file if it is expected to be there

### DIFF
--- a/osfoffline/polling_osf_manager/polling.py
+++ b/osfoffline/polling_osf_manager/polling.py
@@ -585,7 +585,7 @@ class Poll(object):
             new_remote_file = yield from self.osf_query.upload_file(local_file)
         except FileNotFoundError:
             logger.warning(
-                'file not reuploaded on remote server because does not exist locally. it probably downloaded incorrectly. inside create_remote_file_folder')
+                'file {} not reuploaded on remote server because does not exist locally. it probably downloaded incorrectly.'.format(local_file.name))
             yield from self.update_local_file(local_file, remote_file)
             return remote_file
 

--- a/osfoffline/polling_osf_manager/polling.py
+++ b/osfoffline/polling_osf_manager/polling.py
@@ -6,6 +6,7 @@ import time
 
 import aiohttp
 import iso8601
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 import osfoffline.alerts as AlertHandler
@@ -585,7 +586,8 @@ class Poll(object):
             new_remote_file = yield from self.osf_query.upload_file(local_file)
         except FileNotFoundError:
             logger.warning(
-                'file not reuploaded on remote server because does not exist locally. inside create_remote_file_folder')
+                'file not reuploaded on remote server because does not exist locally. it probably downloaded incorrectly. inside create_remote_file_folder')
+            yield from self.update_local_file(local_file, remote_file)
             return remote_file
 
         return new_remote_file

--- a/osfoffline/polling_osf_manager/polling.py
+++ b/osfoffline/polling_osf_manager/polling.py
@@ -6,7 +6,6 @@ import time
 
 import aiohttp
 import iso8601
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 import osfoffline.alerts as AlertHandler


### PR DESCRIPTION
Purpose
======
If a download fails, we should try to download it on subsequent syncs.

Changes
=======
A failed download will be retried on next sync


Side effects
=========
A file that was deleted when OSFO was not watching will be redownloaded (probably desired behavior)

Test Notes
---------------
Some fixes have gone in to limit the number of failed downloads, but it's still possible in the case of a failed connection, and possibly other cases. In any case, when a `File` object is successfully added to the database but not the filesystem, we should retry the download.

1) I un-fixed the bug from #75 for testing, but disconnecting wifi in the middle of a sync should work just as well. With several failed downloads, there should be log statements similar to `file {filename} not reuploaded on remote server because does not exist locally.` in the log file. Press `Sync Now` while using this code, and the listed `{filename}`s should be marked for download again.

2) Open `Settings` or close application to halt polling. Delete a file locally. When syncing restarts (when the application restarts), the deleted file should be downloaded again. Note: this does not affect files deleted **while** the application is watching