### PR TITLE
[Feature] Drop first user on login of second

### DIFF
--- a/osfoffline/database_manager/__init__.py
+++ b/osfoffline/database_manager/__init__.py
@@ -1,1 +1,3 @@
-__author__ = 'himanshu'
+from osfoffline.database_manager.models import User, Node, File
+
+CORE_OSFO_MODELS = [User, Node, File]

--- a/osfoffline/database_manager/db.py
+++ b/osfoffline/database_manager/db.py
@@ -2,6 +2,7 @@ import contextlib
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
+from osfoffline.database_manager import CORE_OSFO_MODELS
 from osfoffline.database_manager.models import Base
 from osfoffline.settings import PROJECT_DB_FILE
 
@@ -28,3 +29,7 @@ def drop_db():
         for table in reversed(Base.metadata.sorted_tables):
             con.execute(table.delete())
         trans.commit()
+
+def clear_models():
+    for model in CORE_OSFO_MODELS:
+        session.query(model).delete()

--- a/osfoffline/utils/authentication.py
+++ b/osfoffline/utils/authentication.py
@@ -108,6 +108,10 @@ class AuthClient(object):
 
         if user:
             user.oauth_token = yield from self._authenticate(username, password)
+            if user.osf_login != username:
+                #Different user authenticated, drop old user and allow login
+                session.query(User).delete()
+                user = yield from self._create_user(username, password)
         else:
             user = yield from self._create_user(username, password)
 

--- a/osfoffline/utils/authentication.py
+++ b/osfoffline/utils/authentication.py
@@ -8,7 +8,7 @@ import furl
 from sqlalchemy.exc import SQLAlchemyError
 
 from osfoffline import settings
-from osfoffline.database_manager.db import session
+from osfoffline.database_manager.db import clear_models, session
 from osfoffline.database_manager.models import User
 from osfoffline.database_manager.utils import save
 from osfoffline.polling_osf_manager.remote_objects import RemoteUser
@@ -110,7 +110,7 @@ class AuthClient(object):
             user.oauth_token = yield from self._authenticate(username, password)
             if user.osf_login != username:
                 #Different user authenticated, drop old user and allow login
-                session.query(User).delete()
+                clear_models()
                 user = yield from self._create_user(username, password)
         else:
             user = yield from self._create_user(username, password)

--- a/osfoffline/views/preferences.py
+++ b/osfoffline/views/preferences.py
@@ -175,6 +175,7 @@ class Preferences(QDialog):
 
     def reset_tree_widget(self):
         self.tree_items.clear()
+        self.checked_items.clear()
         self.preferences_window.treeWidget.clear()
 
     @QtCore.pyqtSlot(list)

--- a/osfoffline/views/preferences.py
+++ b/osfoffline/views/preferences.py
@@ -84,6 +84,7 @@ class Preferences(QDialog):
             pass
         else:
             self.preferences_closed_signal.emit()
+        self.reset_tree_widget()
         event.accept()
 
     def alerts_changed(self):


### PR DESCRIPTION
Purpose
=======
If a second user tries to log in, drop all db models relating to first, and allow login

Changes
=======
* Support for above
* Helper fucntion that drops db without causing the next `save` to raise errors

Side Effects
==========
None