### PR TITLE
[WIP] Make move events be top down instead of bottom up OSF-5190

### DIFF
--- a/osfoffline/application/background.py
+++ b/osfoffline/application/background.py
@@ -3,8 +3,11 @@ import asyncio
 import logging
 import threading
 
-from watchdog.observers import Observer
-
+from watchdog.observers.api import (
+    BaseObserver,
+    DEFAULT_OBSERVER_TIMEOUT
+)
+from osfoffline.filesystem_manager.top_down_move_event_emitter import TopDownMovePollingEmitter
 
 from osfoffline.database_manager import models
 from osfoffline.database_manager.db import session
@@ -85,10 +88,11 @@ class BackgroundWorker(threading.Thread):
             loop=self.loop
         )
 
-        # todo: if config actually has legitimate data. use it.
-
         # start
-        self.observer = Observer()  # create observer. watched for events on files.
+
+        # create observer. watched for events on files.
+        self.observer = BaseObserver(TopDownMovePollingEmitter, DEFAULT_OBSERVER_TIMEOUT)
+
         # attach event handler to observed events. make observer recursive
         self.observer.schedule(self.event_handler, self.osf_folder, recursive=True)
 

--- a/osfoffline/filesystem_manager/top_down_move_event_emitter.py
+++ b/osfoffline/filesystem_manager/top_down_move_event_emitter.py
@@ -1,0 +1,58 @@
+from watchdog.utils.dirsnapshot import DirectorySnapshotDiff
+from watchdog.observers.polling import PollingEmitter
+from watchdog.events import (
+    DirMovedEvent,
+    DirDeletedEvent,
+    DirCreatedEvent,
+    DirModifiedEvent,
+    FileMovedEvent,
+    FileDeletedEvent,
+    FileCreatedEvent,
+    FileModifiedEvent
+)
+
+class TopDownMovePollingEmitter(PollingEmitter):
+    """
+    Platform-independent emitter that polls a directory to detect file
+    system changes.
+
+    For move event,
+    """
+
+    def queue_events(self, timeout):
+        # We don't want to hit the disk continuously.
+        # timeout behaves like an interval for polling emitters.
+        if self.stopped_event.wait(timeout):
+            return
+
+        with self._lock:
+            if not self.should_keep_running():
+                return
+
+            # Get event diff between fresh snapshot and previous snapshot.
+            # Update snapshot.
+            new_snapshot = self._take_snapshot()
+            events = DirectorySnapshotDiff(self._snapshot, new_snapshot)
+            self._snapshot = new_snapshot
+
+            # Files.
+            for src_path in events.files_deleted:
+                self.queue_event(FileDeletedEvent(src_path))
+            for src_path in events.files_modified:
+                self.queue_event(FileModifiedEvent(src_path))
+            for src_path in events.files_created:
+                self.queue_event(FileCreatedEvent(src_path))
+
+            for src_path, dest_path in reversed(events.dirs_moved):
+                self.queue_event(DirMovedEvent(src_path, dest_path))
+            for src_path, dest_path in events.files_moved:
+                self.queue_event(FileMovedEvent(src_path, dest_path))
+
+            # Directories.
+            for src_path in events.dirs_deleted:
+                self.queue_event(DirDeletedEvent(src_path))
+            for src_path in events.dirs_modified:
+                self.queue_event(DirModifiedEvent(src_path))
+            for src_path in events.dirs_created:
+                self.queue_event(DirCreatedEvent(src_path))
+

--- a/osfoffline/settings/local-dist.py
+++ b/osfoffline/settings/local-dist.py
@@ -3,5 +3,5 @@ POLL_DELAY = 5  # seconds
 
 LOG_LEVEL = 'DEBUG'
 
-API_BASE = 'http://www.osf-api.io'
+API_BASE = 'http://localhost:8000'
 FILE_BASE = 'http://localhost:7777'  # FIXME: Dev mode currently does not work with local waterbutler (abought)

--- a/osfoffline/settings/local-dist.py
+++ b/osfoffline/settings/local-dist.py
@@ -3,5 +3,5 @@ POLL_DELAY = 5  # seconds
 
 LOG_LEVEL = 'DEBUG'
 
-API_BASE = 'http://localhost:8000'
+API_BASE = 'http://www.osf-api.io'
 FILE_BASE = 'http://localhost:7777'  # FIXME: Dev mode currently does not work with local waterbutler (abought)


### PR DESCRIPTION
See osf-5190 on jira 

Problem Statement:

OSFEventHandler._get_parent_item_from_path(dest_path) works by simply stripping the rightmost item in the dest_path and then searching the database for an item with that new path. This fails when you are moving an entire directory with nested files because watchdog sends events for each file in the nested hierarchy. For example, say we have the folder structure:
A
-----C
--------myfile.txt
B 
and we move C to be under B. Watchdog will give us the events the following order:
1) Moved file: A/C/myfile.txt to B/C/myfile.txt
2) Moved directory: A/C to B/C

We would try and work with the file moved event first in the code, however, the parent for the destination (B/C) does not exist and so we end up raising an error.
What would be preferred is that watchdog only send us the event for moving the directory A/C to B/C because technically that is all that we were trying to do. The internal files just happened to be there, but we do not really care for them. If not that, then it could also work if watchdog gives us the events in reverse order - the folder and then the internal file. This would allow us to ensure that the folder is moved in the database before moving the file.
