### PR TITLE
Exclude registrations from API request

### DIFF
--- a/osfoffline/client/osf.py
+++ b/osfoffline/client/osf.py
@@ -106,7 +106,7 @@ class UserNode(Node):
     """Fetch API data about nodes owned by a specific user"""
     @classmethod
     def get_url(cls, id):
-        return '{}/{}/users/{}/nodes/'.format(cls.OSF_HOST, cls.API_PREFIX, id)
+        return '{}/{}/users/{}/nodes/?filter[registration]=false'.format(cls.OSF_HOST, cls.API_PREFIX, id)
 
 
 class StorageObject(BaseResource):

--- a/osfoffline/gui/qt/preferences.py
+++ b/osfoffline/gui/qt/preferences.py
@@ -176,6 +176,6 @@ class NodeFetcher(QtCore.QObject):
             client_user = client.get_user()
             user_nodes = client_user.get_nodes()
         except Exception as e:
-            logging.warning(e)
+            logging.exception(e)
 
         self.finished.emit([node for node in user_nodes if 'parent' not in node.raw['relationships']])


### PR DESCRIPTION
## Purpose
Fix an issue where the application would crash when viewing list of nodes to sync, if a user owned any registrations.

Modified the API call to exclude any registrations from the list of user nodes.

## Scope
Currently, the API attempts to act on data that may not have been returned from the server. Preferences/py does not currently handle exceptions correctly; that should be fixed separately as part of a broader error handling task.

For now, just changed logging so that we capture the traceback correctly.