### PR TITLE
[review] Basic implementation of consolidated notifications

### DIFF
--- a/osfoffline/gui/qt/tray.py
+++ b/osfoffline/gui/qt/tray.py
@@ -175,8 +175,8 @@ class OSFOfflineQT(QSystemTrayIcon):
                     self._show_notifications(notification_list)
                 else:
                     self.showMessage(
-                        'Updating multiple',
-                        'Updating {} files and folders'.format(len(notification_list)),
+                        'Updated multiple',
+                        'Updated {} files and folders'.format(len(notification_list)),
                         QSystemTrayIcon.NoIcon,
                         msecs=settings.ALERT_DURATION / 1000.
                     )
@@ -240,6 +240,6 @@ class SyncEventHandler(QThread):
 
     def run(self):
         while True:
-            event = self.queue.get()
             self.mutex.lock()
+            event = self.queue.get()
             self.notify_signal.emit(event)

--- a/osfoffline/gui/qt/tray.py
+++ b/osfoffline/gui/qt/tray.py
@@ -1,7 +1,7 @@
 import logging
 import os
-
-from queue import Queue
+from queue import Empty, Queue
+import threading
 
 from PyQt5.Qt import QIcon
 from PyQt5.QtCore import pyqtSignal
@@ -23,6 +23,8 @@ from osfoffline.database.models import User
 from osfoffline.database.utils import save
 from osfoffline.gui.qt.login import LoginScreen
 from osfoffline.gui.qt.menu import OSFOfflineMenu
+from osfoffline import settings
+from osfoffline.tasks.notifications import group_events, Level
 from osfoffline.utils.validators import validate_containing_folder
 
 
@@ -116,19 +118,18 @@ class OSFOfflineQT(QSystemTrayIcon):
         self.intervention_handler.done()
 
     def on_notification(self, notification):
-        # if (alert_icon is None) or (not show_alerts):
-        #     return
+        """
+        Display user-facing event notifications.
 
+        :param notification: An individual notification event
+        :return:
+        """
         if not self.supportsMessages():
             return
 
-        self.showMessage(
-            'Title of The Message!!!',
-            notification.msg,
-            QSystemTrayIcon.NoIcon
-        )
-
-        self.notification_handler.done()
+        # Wait for more notifications, then grab all events and display
+        t = threading.Timer(settings.ALERT_DURATION * 2, self._consolidate_notifications, args=[notification])
+        t.start()
 
     # def resume(self):
     #     logger.debug('resuming')
@@ -142,6 +143,55 @@ class OSFOfflineQT(QSystemTrayIcon):
     #     logger.debug('pausing')
     #     if self.background_handler and self.background_handler.is_alive():
     #         self.background_handler.stop()
+
+    def _consolidate_notifications(self, first_notification):
+        """
+        Consolidates notifications and groups them together. Releases a burst of all notifications that occur in
+        a given window of time after the first message is received.
+        Error messages are always displayed individually.
+
+        :param first_notification: The first notification that triggered the consolidation cycle
+        :return:
+        """
+        # Grab all available events, including the one that kicked off this consolidation cycle
+        available_notifications = [first_notification]
+        while True:
+            try:
+                event = self.notification_handler.queue.get_nowait()
+            except Empty:
+                break
+            else:
+                available_notifications.append(event)
+
+        # Display notifications
+        if len(available_notifications) == 1:
+            # If there's only one message, show it regardless of level
+            self._show_notifications(available_notifications)
+        else:
+            consolidated = group_events(available_notifications)
+            for level, notification_list in consolidated.items():
+                # Group info notifications, but display errors and warnings individually
+                if level > Level.INFO:
+                    self._show_notifications(notification_list)
+                else:
+                    self.showMessage(
+                        'Updating multiple',
+                        'Updating {} files and folders'.format(len(notification_list)),
+                        QSystemTrayIcon.NoIcon,
+                        msecs=settings.ALERT_DURATION / 1000.
+                    )
+
+        self.notification_handler.done()
+
+    def _show_notifications(self, notifications_list):
+        """Show a message bubble for each notification in the list provided"""
+        for n in notifications_list:
+            self.showMessage(
+                'Synchronizing...',
+                n.msg,
+                QSystemTrayIcon.NoIcon,
+                msecs=settings.ALERT_DURATION / 1000.
+            )
 
     def quit(self):
         try:

--- a/osfoffline/settings/defaults.py
+++ b/osfoffline/settings/defaults.py
@@ -20,20 +20,18 @@ FILE_BASE = 'https://test-files.osf.io'
 # Interval (in seconds) to poll the OSF for server-side file changes
 REMOTE_CHECK_INTERVAL = 60 * 5  # Every 5 minutes
 
-# Time to keep alert messages on screen (in milliseconds); may not be configurable on all platforms
-ALERT_TIME = 3000  # ms
+# Time to keep alert messages on screen (in seconds); may not be configurable on all platforms
+ALERT_DURATION = 5.0  # sec
 
 LOG_LEVEL = 'INFO'
 
 # Logging configuration
-FILE_FORMATTER = '[%(asctime)s][%(threadName)s][%(filename)s][%(levelname)s][%(name)s]: %(message)s'
+FILE_FORMATTER = '[%(levelname)s][%(asctime)s][%(threadName)s][%(name)s]: %(message)s'
 
 IGNORED_NAMES = ['.DS_Store', 'lost+found', 'Desktop.ini']
 IGNORED_PATTERNS = ['*.DS_Store', '*lost+found', '*Desktop.ini']
 
 OSF_STORAGE_FOLDER = 'OSF Storage'
-
-LOCAL_DELETE_THRESHOLD = 10
 
 # wab~,vmc,vhd,vo1,vo2,vsv,vud,vmdk,vmsn,vmsd,hdd,vdi,vmwarevm,nvram,vmx,vmem,iso,dmg,sparseimage,wim,ost,o,qtch,log
 # wab~,vmc,vhd,vdi,vo1,vo2,vsv,vud,iso,dmg,sparseimage,sys,cab,exe,msi,dll,dl_,wim,ost,o,qtch,log,ithmb,vmdk,vmem,vmsd,vmsn,vmss,vmx,vmxf,menudata,appicon,appinfo,pva,pvs,pvi,pvm,fdd,hds,drk,mem,nvram,hdd

--- a/osfoffline/tasks/notifications.py
+++ b/osfoffline/tasks/notifications.py
@@ -8,16 +8,18 @@ from osfoffline.utils import Singleton
 logger = logging.getLogger(__name__)
 
 
+class Level(enum.IntEnum):
+    """The severity of the notification event (determines display priority)"""
+    INFO = 0
+    WARNING = 1
+    ERROR = 2
+
+
 class Notification(metaclass=Singleton):
 
-    class Type(enum.Enum):
-        INFO = 0,
-        WARNING = 1,
-        ERROR = 2
-
     class Event:
-
         def __init__(self, type, msg):
+            # TODO: Add additional fields describing event in more detail
             self.type = type
             self.msg = msg
 
@@ -28,16 +30,29 @@ class Notification(metaclass=Singleton):
         self.cb = cb
 
     def info(self, msg):
-        event = self.Event(self.Type.INFO, msg)
+        event = self.Event(Level.INFO, msg)
         logger.info('Notification: {}'.format(event))
         self.cb(event)
 
     def warn(self, msg):
-        event = self.Event(self.Type.WARNING, msg)
+        event = self.Event(Level.WARNING, msg)
         logger.warn('Notification: {}'.format(event))
         self.cb(event)
 
     def error(self, msg):
-        event = self.Event(self.Type.ERROR, msg)
+        event = self.Event(Level.ERROR, msg)
         logger.error('Notification: {}'.format(event))
         self.cb(event)
+
+
+def group_events(event_list):
+    """
+    Group a list of events together based on level
+    :param list event_list: A list of Event objects
+    :return dict: A dictionary of the form {level_enum_value: [events]}
+    """
+    groups = {}
+    for event in event_list:
+        slot = groups.setdefault(event.type, [])
+        slot.append(event)
+    return groups


### PR DESCRIPTION
Refs https://openscience.atlassian.net/browse/OFF-48

## Purpose
Consolidate close-spaced notifications together. Give the user one message, instead of 10.

As is, this doesn't apply any special logic to the grouping. It simply grabs all notifications that occur in a certain span of time. There is an assumption that anything in `notification_queue` must be a file or folder sync operation. CRUD operations are grouped together in a single counter. See notification center screenshot below for example.

![screen shot 2015-12-16 at 4 48 40 pm](https://cloud.githubusercontent.com/assets/2957073/11854911/f1d854e6-a414-11e5-9662-7a65c3673bbd.png)


## Summary of changes
- When a notification fires, wait several seconds and gather all notifications together in a burst. Ensures that the user never has to wait too long for feedback on progress by using a straight timer; may implement debounce option later.
   - INFO messages can be grouped, but messages of a higher severity will always be displayed individually.
- Settings cleanup
   - Remove unused settings
   - Tweak format of log messages
   - Change ALERT_TIME to ALERT_DURATION, and unit to seconds (more consistent with python APIs)

## Test cases
Sync a large project. Try several different ALERT_DURATION values and see the size of the groups change.

## TODO
- [x] Fix straggler bug. Traced to here: https://github.com/CenterForOpenScience/OSF-Offline/blob/develop/osfoffline/gui/qt/tray.py#L194 (one event is being pulled from the queue, out of sequence, before ready)