### PR TITLE
gix the log out button

### DIFF
--- a/osfoffline/gui/qt/tray.py
+++ b/osfoffline/gui/qt/tray.py
@@ -218,7 +218,7 @@ class OSFOfflineQT(QSystemTrayIcon):
         drop_db()
         # Clear any user-specific context data that would be sent to Sentry
         remove_user_from_sentry_logs()
-        self.quit()
+        self.start()
 
 
 class SyncEventHandler(QThread):


### PR DESCRIPTION
<b>Purpose</b>
Fix the log out button of the system tray menu. Now it logs out the user and pop the log in screen instead of quit the application.

solves https://openscience.atlassian.net/browse/OFF-66

Also related to issue https://openscience.atlassian.net/browse/OFF-65 for fixing the logout function. Review and merge this pr in first will save some of @abought 's work.