### PR TITLE
Fix windows sync issues

### DIFF
--- a/osfoffline/database/models.py
+++ b/osfoffline/database/models.py
@@ -49,7 +49,10 @@ class Node(Base):
 
     @property
     def path(self):
-        """Recursively walk up the path of the node. Top level node joins with the osf folder path of the user
+        """
+        Path on the local filesystem.
+
+        Recursively walk up the path of the node. Top level node joins with the osf folder path of the user
         """
         # +os.path.sep+ instead of os.path.join: http://stackoverflow.com/a/14504695
 
@@ -140,19 +143,25 @@ class File(Base):
 
     @property
     def osf_path(self):
+        """
+        APIv1 suffix for the node or folder containing this item (to be used as part of a URL)
+        """
         if not self.parent:
             return ''
-        return self.id + ((self.is_folder and '/') or '')
+        return self.id + '/' if self.is_folder else ''
 
     @property
     def path(self):
-        """Recursively walk up the path of the file/folder. Top level file/folder joins with the path of the containing node.
+        """
+        Local filesystem path to the file or folder.
+
+        Recursively walk up the path of the file/folder. Top level joins with the path of the containing node.
         """
         # +os.path.sep+ instead of os.path.join: http://stackoverflow.com/a/14504695
         if self.parent:
-            return os.path.join(self.parent.path, self.name) + ('/' if self.is_folder else '')
+            return os.path.join(self.parent.path, self.name) + (os.path.sep if self.is_folder else '')
         else:
-            return os.path.join(self.node.path, settings.OSF_STORAGE_FOLDER) + ('/' if self.is_folder else '')
+            return os.path.join(self.node.path, settings.OSF_STORAGE_FOLDER) + (os.path.sep if self.is_folder else '')
 
     def locally_create_children(self):
         self.locally_created = True

--- a/osfoffline/sync/local.py
+++ b/osfoffline/sync/local.py
@@ -94,6 +94,8 @@ class LocalSyncWorker(ConsolidatedEventHandler, metaclass=Singleton):
         context = OperationContext(local=Path(event.src_path), is_folder=event.is_directory)
 
         if event.is_directory:
+            # TODO: May not be able to identify deletion event type on Windows; may rely on auditor to clean up
+            #   https://pythonhosted.org/watchdog/installation.html#supported-platforms-and-caveats
             return self.put_event(operations.RemoteDeleteFolder(context))
         return self.put_event(operations.RemoteDeleteFile(context))
 

--- a/osfoffline/tasks/operations.py
+++ b/osfoffline/tasks/operations.py
@@ -82,7 +82,7 @@ class BaseOperation(abc.ABC):
 
     def run(self, dry=False):
         """Wrap internal run method"""
-        logger.info('{!r}'.format(self))
+        logger.info('Running {!r}'.format(self))
         if not dry:
             return self._run()
 

--- a/osfoffline/tasks/queue.py
+++ b/osfoffline/tasks/queue.py
@@ -28,7 +28,7 @@ class OperationWorker(threading.Thread, metaclass=Singleton):
             if job is None:
                 self._queue.task_done()
                 continue
-            logger.debug('Running {}'.format(job))
+            #logger.debug('Running {}'.format(job))
             try:
                 job.run(dry=settings.DRY)
             except (NodeNotFound, ) as e:

--- a/osfoffline/utils/__init__.py
+++ b/osfoffline/utils/__init__.py
@@ -57,12 +57,12 @@ def extract_node(path):
 
 def local_to_db(local, node, is_folder=False):
     db = Session().query(models.File).filter(models.File.parent == None, models.File.node == node).one()  # noqa
-    parts = str(local).replace(node.path, '').split('/')
+    parts = str(local).replace(node.path, '').split(os.path.sep)
     for part in parts:
         for child in db.children:
             if child.name == part:
                 db = child
-    if db.path.rstrip('/') != str(local).rstrip('/') or db.is_folder != (local.is_dir() or is_folder):
+    if db.path.rstrip(os.path.sep) != str(local).rstrip(os.path.sep) or db.is_folder != (local.is_dir() or is_folder):
         return None
     return db
 

--- a/osfoffline/utils/singleton.py
+++ b/osfoffline/utils/singleton.py
@@ -17,7 +17,7 @@ class SingleInstance:
         basename = os.path.splitext(os.path.abspath(sys.argv[0]))[0].replace(
             "/", "-").replace(":", "").replace("\\", "-") + '-%s' % flavor_id + '.lock'
         self.lockfile = os.path.normpath(
-            tempfile.gettempdir() + '/' + basename)
+            os.path.join(tempfile.gettempdir(), basename))
 
         logging.debug("SingleInstance lockfile: " + self.lockfile)
         if sys.platform == 'win32':


### PR DESCRIPTION
Refs [OFF-62](https://openscience.atlassian.net/browse/OFF-62)

## Purpose
Address problems with sync functionality on Windows operating systems.


## Summary of changes
- Replace several hardcoded OS-specific path separators with `os.path.sep`.
  - Fixes issue where first sync attempt lead to `parent is None` errors, and subsequent attempts lead to database integrity errors
- Add docstrings to clarify differences between methods.

## To do
- [ ] While testing, uncovered a secondary issue: on Windows, creating a new file in a folder fired an `Update` event, instead of a `Create` event. Although sync would complete correctly the second time through, this is not ideal. Problem did not occur on Mac OS and appears to be watchdog related.

- [x] Determine why a database state/uniqueness constraint error was issued. In theory, the database state should not change if the sync operation fails: the DB should not have had an entry for an operation that failed midway through. Seems symptomatic of a deeper issue.
    - This appears to be tied to the conflict resolution mechanism: it can be created with a forward slash in the path, but the auditor tries to find a DB object based on file path (not an exact string match), then creates a File object with a specific OSF id. (the file object was actually there, but not found by the auditor)