### PR TITLE
Fix http imports again (3.4 vs 3.5 changes)

### DIFF
--- a/osfoffline/tasks/operations.py
+++ b/osfoffline/tasks/operations.py
@@ -1,5 +1,5 @@
 import abc
-from http import HTTPStatus
+import http.client
 import logging
 import os
 import json
@@ -196,7 +196,7 @@ class RemoteCreateFile(BaseOperation):
         with self.local.open(mode='rb') as fobj:
             resp = OSFClient().request('PUT', url, data=fobj, params={'name': self.local.name})
         data = resp.json()
-        assert resp.status_code == HTTPStatus.CREATED, '{}\n{}\n{}'.format(resp, url, data)
+        assert resp.status_code == http.client.CREATED, '{}\n{}\n{}'.format(resp, url, data)
 
         remote = osf_client.File(None, data['data'])
         # WB id are <provider>/<id>
@@ -216,7 +216,7 @@ class RemoteCreateFolder(BaseOperation):
         url = '{}/v1/resources/{}/providers/{}/{}'.format(settings.FILE_BASE, self.node.id, parent.provider, parent.osf_path)
         resp = OSFClient().request('PUT', url, params={'kind': 'folder', 'name': self.local.name})
         data = resp.json()
-        assert resp.status_code == HTTPStatus.CREATED, '{}\n{}\n{}'.format(resp, url, data)
+        assert resp.status_code == http.client.CREATED, '{}\n{}\n{}'.format(resp, url, data)
 
         remote = osf_client.File(None, data['data'])
         # WB id are <provider>/<id>/
@@ -235,7 +235,7 @@ class RemoteUpdateFile(BaseOperation):
         with open(str(self.local), 'rb') as fobj:
             resp = OSFClient().request('PUT', url, data=fobj, params={'name': self.local.name})
         data = resp.json()
-        assert resp.status_code in (HTTPStatus.OK, HTTPStatus.CREATED), '{}\n{}\n{}'.format(resp, url, data)
+        assert resp.status_code in (http.client.OK, http.client.CREATED), '{}\n{}\n{}'.format(resp, url, data)
         remote = osf_client.File(None, data['data'])
         # WB id are <provider>/<id>
         remote.id = remote.id.replace(remote.provider + '/', '')
@@ -249,7 +249,7 @@ class RemoteDeleteFile(BaseOperation):
 
     def _run(self):
         resp = osf_client.OSFClient().request('DELETE', self.remote.raw['links']['delete'])
-        assert resp.status_code == HTTPStatus.NO_CONTENT, resp
+        assert resp.status_code == http.client.NO_CONTENT, resp
         DatabaseDeleteFile(OperationContext(db=Session().query(models.File).filter(models.File.id == self.remote.id).one())).run()
         Notification().info('Remote delete file: {}'.format(self.remote))
 
@@ -259,7 +259,7 @@ class RemoteDeleteFolder(BaseOperation):
 
     def _run(self):
         resp = OSFClient().request('DELETE', self.remote.raw['links']['delete'])
-        assert resp.status_code == HTTPStatus.NO_CONTENT, resp
+        assert resp.status_code == http.client.NO_CONTENT, resp
         DatabaseDeleteFolder(OperationContext(db=Session().query(models.File).filter(models.File.id == self.remote.id).one())).run()
         Notification().info('Remote delete older: {}'.format(self.remote))
 
@@ -359,7 +359,7 @@ class RemoteMoveFolder(MoveOperation):
             'resource': self._dest_context.node.id,
         }))
         data = resp.json()
-        assert resp.status_code in (HTTPStatus.CREATED, HTTPStatus.OK), resp
+        assert resp.status_code in (http.client.CREATED, http.client.OK), resp
 
         remote = osf_client.File(None, data['data'])
         # WB id are <provider>/<id>
@@ -383,7 +383,7 @@ class RemoteMoveFile(MoveOperation):
             'resource': self._dest_context.node.id,
         }))
         data = resp.json()
-        assert resp.status_code in (HTTPStatus.CREATED, HTTPStatus.OK), resp
+        assert resp.status_code in (http.client.CREATED, http.client.OK), resp
 
         remote = osf_client.File(None, data['data'])
         # WB id are <provider>/<id>


### PR DESCRIPTION
Codes were moved from 2 to 3, but again from 3.4 to 3.5. This should use the backwards-compatible recommendation for 3.4.

https://docs.python.org/3/library/http.html#http.HTTPStatus