### PR TITLE
Consolidate redundant update events

### DIFF
--- a/osfoffline/sync/ext/watchdog.py
+++ b/osfoffline/sync/ext/watchdog.py
@@ -46,11 +46,13 @@ class ConsolidatedEventHandler(PatternMatchingEventHandler):
             if event.event_type == 'modified':
                 if event.is_directory:
                     return
-                elif parts in self._event_cache:
-                    ev = self._event_cache[parts]
-                    if not isinstance(ev, OrderedDict) and ev.event_type in ('moved', 'created'):
-                        return
-
+                move_events = [
+                    evt
+                    for evt in self._event_cache.children()
+                    if evt.event_type == 'moved' and evt.dest_path == event.src_path
+                ]
+                if move_events:
+                    return
             if event.event_type == 'created':
                 self._create_cache.append(event)
             else:

--- a/osfoffline/sync/ext/watchdog.py
+++ b/osfoffline/sync/ext/watchdog.py
@@ -43,8 +43,13 @@ class ConsolidatedEventHandler(PatternMatchingEventHandler):
             if event.event_type == 'deleted':
                 consolidate = (parts in self._event_cache)
 
-            if event.is_directory and event.event_type == 'modified':
-                return
+            if event.event_type == 'modified':
+                if event.is_directory:
+                    return
+                elif parts in self._event_cache:
+                    ev = self._event_cache[parts]
+                    if not isinstance(ev, OrderedDict) and ev.event_type in ('moved', 'created'):
+                        return
 
             if event.event_type == 'created':
                 self._create_cache.append(event)


### PR DESCRIPTION
Windows sends an update event immediately after a create/move event in some cases. Tweak consolidation to get rid of the extra event.

(prevent duplicate OSF traffic for spurious "updates" being sent to the server, and potentially simplify for some failing unit tests due to windows watchdog differences)