### PR TITLE
Sort projects in alphabetical order in settings

### DIFF
--- a/osfoffline/gui/qt/preferences.py
+++ b/osfoffline/gui/qt/preferences.py
@@ -168,7 +168,7 @@ class Preferences(QDialog, Ui_Settings):
         _translate = QCoreApplication.translate
         self.selected_nodes = [n.id for n in Session().query(Node)]
 
-        for node in nodes:
+        for node in sorted(nodes, key=lambda n: n.title):
             tree_item = QTreeWidgetItem(self.treeWidget)
             tree_item.setCheckState(self.PROJECT_SYNC_COLUMN, Qt.Checked if node.id in self.selected_nodes else Qt.Unchecked)
             tree_item.setText(self.PROJECT_NAME_COLUMN, _translate('Preferences', '{} - {}'.format(node.title, node.id)))


### PR DESCRIPTION
## Purpose 
Sort projects in alphabetical order in settings

## Changes
Sort by title on each node in the tree list 

## Side effects
None, `sorted` doesn't sort in place but returns a new list.

[OFF-15]