### PR TITLE
[RFR] Handle remote deletion of resources

### DIFF
--- a/osfoffline/application/background.py
+++ b/osfoffline/application/background.py
@@ -46,3 +46,7 @@ class BackgroundHandler(metaclass=Singleton):
         OperationWorker().stop()
         RemoteSyncWorker().stop()
         LocalSyncWorker().stop()
+
+        OperationWorker().join()
+        RemoteSyncWorker().join()
+        LocalSyncWorker().join()

--- a/osfoffline/application/background.py
+++ b/osfoffline/application/background.py
@@ -43,8 +43,8 @@ class BackgroundHandler(metaclass=Singleton):
         RemoteSyncWorker().sync_now()
 
     def stop(self):
-        OperationWorker().stop()
         RemoteSyncWorker().stop()
+        OperationWorker().stop()
         LocalSyncWorker().stop()
 
         del type(OperationWorker)._instances[OperationWorker]

--- a/osfoffline/application/background.py
+++ b/osfoffline/application/background.py
@@ -47,6 +47,6 @@ class BackgroundHandler(metaclass=Singleton):
         RemoteSyncWorker().stop()
         LocalSyncWorker().stop()
 
-        OperationWorker().join()
-        RemoteSyncWorker().join()
-        LocalSyncWorker().join()
+        del type(OperationWorker)._instances[OperationWorker]
+        del type(RemoteSyncWorker)._instances[RemoteSyncWorker]
+        del type(LocalSyncWorker)._instances[LocalSyncWorker]

--- a/osfoffline/client/osf.py
+++ b/osfoffline/client/osf.py
@@ -67,6 +67,12 @@ class BaseResource(abc.ABC):
     @classmethod
     def load(cls, request_session, *args, **kwargs):
         resp = request_session.get(cls.get_url(*args, **kwargs), params={'page[size]': 250})
+        if (resp.status_code % 500) <= 100:
+            raise ClientLoadError(
+                resource=cls.RESOURCE,
+                status=resp.status_code,
+                errors=['Server error']
+            )
         data = resp.json()
 
         if 'errors' in data:

--- a/osfoffline/client/osf.py
+++ b/osfoffline/client/osf.py
@@ -67,7 +67,7 @@ class BaseResource(abc.ABC):
     @classmethod
     def load(cls, request_session, *args, **kwargs):
         resp = request_session.get(cls.get_url(*args, **kwargs), params={'page[size]': 250})
-        if (resp.status_code % 500) <= 100:
+        if resp.status_code >= 500:
             raise ClientLoadError(
                 resource=cls.RESOURCE,
                 status=resp.status_code,

--- a/osfoffline/client/osf.py
+++ b/osfoffline/client/osf.py
@@ -11,6 +11,14 @@ from osfoffline.utils import Singleton
 from osfoffline.utils.authentication import get_current_user
 
 
+class ClientLoadError(Exception):
+
+    def __init__(self, *args, resource=None, status=None, errors=None):
+        super(ClientLoadError, self).__init__(*args)
+        self.resource = resource
+        self.status = status
+        self.errors = errors
+
 class OSFClient(metaclass=Singleton):
 
     def __init__(self, *, limit=5):
@@ -60,6 +68,13 @@ class BaseResource(abc.ABC):
     def load(cls, request_session, *args, **kwargs):
         resp = request_session.get(cls.get_url(*args, **kwargs), params={'page[size]': 250})
         data = resp.json()
+
+        if 'errors' in data:
+            raise ClientLoadError(
+                resource=cls.RESOURCE,
+                status=resp.status_code,
+                errors=data['errors']
+            )
 
         if isinstance(data['data'], list):
             l = data['data']
@@ -182,6 +197,13 @@ class StorageObject(BaseResource):
     def load(cls, request_session, *args):
         resp = request_session.get(cls.get_url(*args), params={'page[size]': 250})
         data = resp.json()
+
+        if 'errors' in data:
+            raise ClientLoadError(
+                resource=cls.RESOURCE,
+                status=resp.status_code,
+                errors=data['errors']
+            )
 
         if isinstance(data['data'], list):
             return [

--- a/osfoffline/gui/qt/login.py
+++ b/osfoffline/gui/qt/login.py
@@ -49,7 +49,6 @@ class LoginScreen(QDialog, Ui_login):
         return self.user
 
     def login(self, *, otp=None):
-        # self.start_screen.logInButton.setDisabled(True)  # Doesn't update until the asyncio call below returns
         logger.debug('attempting to log in')
         username = self.usernameEdit.text()
         password = self.passwordEdit.text()

--- a/osfoffline/sync/local.py
+++ b/osfoffline/sync/local.py
@@ -35,7 +35,7 @@ class LocalSyncWorker(ConsolidatedEventHandler, metaclass=Singleton):
         logger.debug('Stopping LocalSyncWorker')
         # observer is actually a separate child thread and must be join()ed
         self.observer.stop()
-        del type(self.__class__)._instances[self.__class__]
+        self.join()
 
     def join(self):
         self.observer.join()

--- a/osfoffline/sync/remote.py
+++ b/osfoffline/sync/remote.py
@@ -97,7 +97,6 @@ class RemoteSyncWorker(threading.Thread, metaclass=Singleton):
         logger.info('Stopping RemoteSyncWorker')
         self.__stop.set()
         self.sync_now()
-        del type(self.__class__)._instances[self.__class__]
 
     def _orphan_children(self, node, remote_children):
         """It's a hard world out there...

--- a/osfoffline/sync/remote.py
+++ b/osfoffline/sync/remote.py
@@ -106,10 +106,13 @@ class RemoteSyncWorker(threading.Thread, metaclass=Singleton):
         locally for which the remote Node has been deleted are explicitly removed
         from OSFO's auditing and will be ignored.
         """
-        children_ids = map(lambda c: c.id, remote_children)
+        children_ids = [c.id for c in remote_children]
         for record in node.children:
             if record.id not in children_ids:
                 Session().delete(record)
+            else:
+                remote_child = OSFClient().get_node(record.id)
+                self._orphan_children(record, remote_child.get_children(lazy=False))
 
     def _preprocess_node(self, node, *, delete=True):
         nodes = [node]

--- a/osfoffline/sync/remote.py
+++ b/osfoffline/sync/remote.py
@@ -79,6 +79,7 @@ class RemoteSyncWorker(threading.Thread, metaclass=Singleton):
                     # TODO: Should the error be user-facing?
                     logger.exception('Error creating node directory for sync')
 
+            Session().commit()
             OperationWorker().join_queue()
 
             try:

--- a/osfoffline/tasks/queue.py
+++ b/osfoffline/tasks/queue.py
@@ -47,7 +47,6 @@ class OperationWorker(threading.Thread, metaclass=Singleton):
         self.__stop.set()
         self._queue.put(None)
         self.join_queue()
-        del type(self.__class__)._instances[self.__class__]
 
     def put(self, operation):
         self._queue.put(operation)


### PR DESCRIPTION
# Followup (for a later PR)

We should find a way to shut down the RemoteSyncWorker and OperationWorker without waiting for their queues to be flushed. When a user logs out we're dropping the database anyways, and letting the sync operations finish adds unnecessary work and delay to the logout process. 

# Purpose

see: 
https://openscience.atlassian.net/browse/OFF-85
https://openscience.atlassian.net/browse/OFF-86

tldr: deleting a project that was synced locally would cause the remote sync loop to hang

# Changes

- add ClientLoadError as a generic exception for API requests that fail for some reason
- try/except Node loads in RemoteSyncWorker's#_preprocess_node, and explicitly hander 4XX status codes
- some other cleanup from https://github.com/CenterForOpenScience/OSF-Offline/pull/125, in particular with consolidation/unification of how we shut down workers